### PR TITLE
No longer weight those with high upchecks above others.

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -10,7 +10,7 @@ router.get('/', (req, res) => {
 			instance.uptime = (100 * (instance.upchecks / (instance.upchecks + instance.downchecks)));
 			instance.uptime_str = instance.uptime.toFixed(3);
 
-			instance.score = instance.uptime * (instance.upchecks / 1440);
+			instance.score = instance.uptime;
 
 			if(instance.up)
 				instance.score += 5;


### PR DESCRIPTION
Here is the current list of instances by rank:

| | Instance | Users | Registrations | Uptime | HTTPS | IPv6 |
|  - |:------------- |:-------------:|-------------:|-------------:|-------------:| -----:|
UP | memetastic.space | 1798 | Yes | 100.000% | B | No | 
UP | animalliberation.social | 401 | Yes | 99.858% | B | No | 
UP | social.lou.lt | 2737 | Yes | 100.000% | A+ | Yes | 
UP | masto.themimitoof.fr | 949 | Yes | 99.747% | A+ | Yes | 
UP | mastodon.ninetailed.uk | 398 | Yes | 99.884% | B | Yes | 
UP | aleph.land | 400 | Yes | 99.723% | A+ | No | 
UP | social.alex73630.xyz | 190 | Yes | 98.656% | A+ | Yes | 
UP | mastodon.gougere.fr | 888 | Yes | 100.000% | A+ | No | 
UP | social.wxcafe.net | 505 | Yes | 99.858% | A+ | Yes | 
UP | 7nw.eu | 98 | Yes | 97.963% | A | Yes | 
UP | oc.todon.fr | 850 | Yes | 100.000% | A+ | Yes | 
UP | social.tcit.fr | 114 | Yes | 99.355% | A+ | Yes | 
UP | hex.bz | 211 | Yes | 99.893% | A+ | Yes | 

The top two have `B` HTTPS scores and no IPv6. They have good uptime, but not much better than any below them. 

To try to correct this, we need to stop giving so much priority to older servers, which have more upchecks. 

Because we were doing `instance.score = instance.uptime * (instance.upchecks / 1440);`, a server with ~50 more upchecks gains as much ranking points as a server having IPv6. While it may be important to consider the age of the server, as this database grows older, if we keep it how it is, it will be increasingly hard for a new server to gain popularity.