### PR TITLE
adjust mobile nav so that menu button and title do not overlap

### DIFF
--- a/views/layout.njk
+++ b/views/layout.njk
@@ -15,10 +15,10 @@
     </head>
     <body>
         <nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
             <div class="container">
-                <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
                 <a class="navbar-brand" href="/">Mastodon instances</a>
 
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">


### PR DESCRIPTION
Currently, in various mobile views, the hamburger menu icon overlaps with the "Mastodon instances" title:
![mobile-menu-current](https://user-images.githubusercontent.com/14248644/45589777-f0231a80-b8f9-11e8-9d65-17166c0ab09e.JPG)

It appears this is because the `button` div is scoped inside of the same `"container"` class as the title, so the absolute position only goes to the end of the title instead of the end of the screen.  By moving the button up one level in the HTML, the CSS correctly shows the menu on the right side of the title:
**iPhone**
![mobile-menu-fixed-iphone](https://user-images.githubusercontent.com/14248644/45589793-22347c80-b8fa-11e8-8a5d-689ebb84e24f.JPG)

**iPad**
![mobile-menu-fixed-ipad](https://user-images.githubusercontent.com/14248644/45589795-2bbde480-b8fa-11e8-84dd-98534cb38e06.JPG)

**508 Note**:  The button needs to be _before_ the div with the menu items so that those menu items are correctly added to tab order when a user opens the menu.  More to the point, if the button is _after_ the div with menu items and a user opens the menu with their keyboard and continues to tab through the site, they will not be taken to the "revealed content."