### PR TITLE
Strip tags/build metadata from instance versions

### DIFF
--- a/models/instance.js
+++ b/models/instance.js
@@ -113,8 +113,8 @@ Instance.hook('afterSave', async (instance) => {
     if(instance.raw_version)
         version = raw_version = instance.raw_version.replace(/\.$/, '');
 
-    let version_norc = version.replace(/\.?rc[0-9]/, '');
-    version_norc = version_norc.replace(/\+[0-9A-Za-z.-]*/, '');
+    let version_notag = version_norc.replace(/\+[0-9A-Za-z.-]*/, '');
+    let version_norc = version_notag.replace(/\.?rc[0-9]/, '');
 
     if(version === 'Mastodon::Version') {
         version = '1.3';

--- a/models/instance.js
+++ b/models/instance.js
@@ -114,6 +114,7 @@ Instance.hook('afterSave', async (instance) => {
         version = raw_version = instance.raw_version.replace(/\.$/, '');
 
     let version_norc = version.replace(/\.?rc[0-9]/, '');
+    version_norc = version_norc.replace(/\+[0-9A-Za-z.-]*/, '');
 
     if(version === 'Mastodon::Version') {
         version = '1.3';

--- a/models/instance.js
+++ b/models/instance.js
@@ -113,7 +113,7 @@ Instance.hook('afterSave', async (instance) => {
     if(instance.raw_version)
         version = raw_version = instance.raw_version.replace(/\.$/, '');
 
-    let version_notag = version_norc.replace(/\+[0-9A-Za-z.-]*/, '');
+    let version_notag = version.replace(/\+[0-9A-Za-z.-]*/, '');
     let version_norc = version_notag.replace(/\.?rc[0-9]/, '');
 
     if(version === 'Mastodon::Version') {

--- a/models/instance.js
+++ b/models/instance.js
@@ -113,7 +113,7 @@ Instance.hook('afterSave', async (instance) => {
     if(instance.raw_version)
         version = raw_version = instance.raw_version.replace(/\.$/, '');
 
-    let version_notag = version.replace(/\+[0-9A-Za-z.-]*/, '');
+    let version_notag = version.replace(/\+[0-9A-Za-z\.-]*/, '');
     let version_norc = version_notag.replace(/\.?rc[0-9]/, '');
 
     if(version === 'Mastodon::Version') {


### PR DESCRIPTION
Glitch-soc is going to use `+glitch`, see https://semver.org/#spec-item-10 and https://github.com/glitch-soc/mastodon/pull/716