### PR TITLE
Realign the 'toggle column' columns with the main table.

### DIFF
--- a/views/list.njk
+++ b/views/list.njk
@@ -99,9 +99,10 @@
                                 <a class="toggle-column" data-column="4" href="#">connections</a>
                                 <a class="toggle-column" data-column="5" href="#">registrations</a>
                                 <a class="toggle-column" data-column="6" href="#">version</a>
-                                <a class="toggle-column" data-column="7" href="#">uptime</a>
-                                <a class="toggle-column" data-column="8" href="#">https</a>
-                                <a class="toggle-column" data-column="9" href="#">obs</a>
+                                <a class="toggle-column" data-column="7" href="#">ipv6</a>
+                                <a class="toggle-column" data-column="8" href="#">uptime</a>
+                                <a class="toggle-column" data-column="9" href="#">https</a>
+                                <a class="toggle-column" data-column="10" href="#">obs</a>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Right now, toggling "uptime", "https" or "obs" toggles the column to the left of the selected one, and there is no toggle for IPv6. This PR fixes the column selectors to match the table.

It is completely untested as I have no clue about how to set up MongoDB, and don't fancy doing so to test such a little fix. :p I hope this isn't too bad.